### PR TITLE
feat: allow custom meta data for tokens

### DIFF
--- a/src/__tests__/lexer.ts
+++ b/src/__tests__/lexer.ts
@@ -6,7 +6,17 @@ describe('Lexer', () => {
     TEST_TOKEN_B,
     ERROR_TOKEN,
   }
-  let lexer: Lexer<TokenType>;
+
+  enum SubTokenType {
+    TEST_TOKEN_SUB,
+  }
+
+  interface ITokenData {
+    subType?: SubTokenType;
+    randomData?: string;
+  }
+
+  let lexer: Lexer<TokenType, ITokenData>;
 
   beforeEach(() => (lexer = new Lexer('abcd')));
 
@@ -46,6 +56,8 @@ describe('Lexer', () => {
       lexer.emit(TokenType.TEST_TOKEN);
 
       expect(lexer.emittedTokens[0]).toEqual({
+        endPos: 2,
+        startPos: 0,
         type: TokenType.TEST_TOKEN,
         value: 'ab',
       });
@@ -59,6 +71,27 @@ describe('Lexer', () => {
       expect(lexer.currentPos).toBe(2);
       expect(lexer.startPos).toBe(2);
     });
+
+    it('should allow custom data to be passed', () => {
+      lexer.next();
+      lexer.emit(TokenType.TEST_TOKEN, {
+        randomData: 'test',
+        subType: SubTokenType.TEST_TOKEN_SUB,
+      });
+
+      expect(lexer.emittedTokens).toEqual([
+        {
+          data: {
+            randomData: 'test',
+            subType: SubTokenType.TEST_TOKEN_SUB,
+          },
+          endPos: 1,
+          startPos: 0,
+          type: TokenType.TEST_TOKEN,
+          value: 'a',
+        },
+      ]);
+    });
   });
 
   describe('#emitError', () => {
@@ -66,6 +99,8 @@ describe('Lexer', () => {
       lexer.emitError(TokenType.ERROR_TOKEN, 'test');
       expect(lexer.emittedTokens).toEqual([
         {
+          endPos: 0,
+          startPos: 0,
           type: TokenType.ERROR_TOKEN,
           value: 'test',
         },
@@ -92,6 +127,8 @@ describe('Lexer', () => {
       lexer.emit(TokenType.TEST_TOKEN);
 
       expect(lexer.lookBehind()).toEqual({
+        endPos: 1,
+        startPos: 0,
         type: TokenType.TEST_TOKEN,
         value: 'a',
       });
@@ -186,11 +223,17 @@ describe('Lexer', () => {
       expect(
         lexer.lookBehindForTypes(TokenType.TEST_TOKEN, TokenType.TEST_TOKEN_B),
       ).toEqual({
+        data: undefined,
+        endPos: 3,
+        startPos: 2,
         type: TokenType.TEST_TOKEN_B,
         value: 'c',
       });
 
       expect(lexer.lookBehindForTypes(TokenType.TEST_TOKEN)).toEqual({
+        data: undefined,
+        endPos: 2,
+        startPos: 1,
         type: TokenType.TEST_TOKEN,
         value: 'b',
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Lexer, ILexToken, EOS } from './lexer';
+export { Lexer, IBaseLexToken, EOS } from './lexer';


### PR DESCRIPTION
This PR enables users to pass custom meta data when emitting their tokens. This enables use cases where we for example want to divide token types into sub groups. Since not everyone needs this, this kind of data should go into meta data, which is now possible. Additionally this PR adds `startPos` and `endPos` to the emitted tokens.